### PR TITLE
Update panel.xml

### DIFF
--- a/bonanza-g36-improvement-project/SimObjects/Airplanes/Asobo_Bonanza_G36/panel/panel.xml
+++ b/bonanza-g36-improvement-project/SimObjects/Airplanes/Asobo_Bonanza_G36/panel/panel.xml
@@ -78,7 +78,7 @@
 
 		<Annunciation>
 			<Type>Warning</Type>
-			<Text>GEAR UP</Text>		
+			<Text>GEAR UP</Text>
 			<Condition>
 				<And>
 					<Simvar name="IS GEAR RETRACTABLE" unit="Boolean"/>
@@ -121,7 +121,7 @@
 				</And>
 			</Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 			<Type>Caution</Type>
 			<Text>BUS1 VOLT HI</Text>
@@ -132,7 +132,7 @@
 			</Greater>
 			</Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 			<Type>Caution</Type>
 			<Text>BUS2 VOLT HI</Text>
@@ -143,7 +143,7 @@
 			</Greater>
 			</Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 			<Type>Warning</Type>
 			<Text>ALT 1 INOP</Text>
@@ -156,7 +156,7 @@
 				</And>
 			</Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 			<Type>Warning</Type>
 			<Text>ALT 2 INOP</Text>
@@ -169,7 +169,7 @@
 				</And>
 			</Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 			<Type>Warning</Type>
 			<Text>ALT 1-2 INOP</Text>
@@ -185,7 +185,17 @@
 			</Condition>
 		</Annunciation>
 
-		
+		<Annunciation>
+			<Type>Caution</Type>
+			<Text>STARTER ENGD</Text>
+			<Condition>
+				<And>
+					<Simvar name="ENG COMBUSTION:1" unit="Boolean"/>
+					<Simvar name="GENERAL ENG STARTER:1" unit="Boolean"/>
+				</And>
+			</Condition>
+		</Annunciation>
+
 		<Annunciation>
 			<Type>Caution</Type>
 			<Text>PITOT FAIL</Text>
@@ -204,7 +214,7 @@
 			</Condition>
 		</Annunciation>
 		-->
-		
+
 		<Annunciation>
 			<Type>Caution</Type>
 			<Text>CHECK GEAR</Text>
@@ -249,7 +259,7 @@
 				</Or>
 			</Condition>
 		</Annunciation>
-		
+
 		<Annunciation>
 			<Type>Advisory</Type>
 			<Text>BUSES TIED</Text>
@@ -262,11 +272,11 @@
 		</Annunciation>
 
 	</Annunciations>
-	
+
 	  <!-- Voices Alerts -->
-  
+
   <VoicesAlerts>
-  
+
 	<Alert>
 		<Type>SoundOnly</Type>
 		<SoundEvent>aural_500ft</SoundEvent>
@@ -296,7 +306,7 @@
 			</StateMachine>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>SoundOnly</Type>
 		<SoundEvent>aural_stall</SoundEvent>
@@ -304,7 +314,7 @@
 			<Simvar name="STALL WARNING" unit="Bool"/>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>Warning</Type>
 		<ShortText>PULL UP</ShortText>
@@ -333,7 +343,7 @@
 			</And>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>SoundOnly</Type>
 		<SoundEvent>aural_overspeed</SoundEvent>
@@ -341,7 +351,7 @@
 			<Simvar name="OVERSPEED WARNING" unit="bool"/>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>Caution</Type>
 		<ShortText>TERRAIN</ShortText>
@@ -371,7 +381,7 @@
 				</And>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>Caution</Type>
 		<ShortText>TERRAIN</ShortText>
@@ -426,7 +436,7 @@
 			</And>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>SoundOnly</Type>
 		<SoundEvent>aural_landing_gear</SoundEvent>
@@ -449,7 +459,7 @@
 			</And>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>Test</Type>
 		<ShortText>TAWS TEST</ShortText>
@@ -463,7 +473,7 @@
 			</And>
 		</Condition>
 	</Alert>
-	
+
 	<Alert>
 		<Type>SoundOnly</Type>
 		<SoundEvent>aural_taws_system_test_ok</SoundEvent>
@@ -480,11 +490,11 @@
 	</Alert>
 
   </VoicesAlerts>
-	
+
 	<!-- Engine Display -->
 
   <EngineDisplay>
-  
+
 	  <Gauge>
 		<Type>Circular</Type>
 		<ID>MANIN_Gauge</ID>
@@ -505,7 +515,7 @@
 			<End>29.6</End>
 		</ColorZone>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>Circular</Type>
 		<ID>Piston_RPMGauge</ID>
@@ -541,7 +551,7 @@
 			</Greater>
 		</RedBlink>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>Horizontal</Type>
 		<ID>Piston_FFlowGauge</ID>
@@ -565,7 +575,7 @@
 		<GraduationLength>2</GraduationLength>
 		<GraduationTextLength>30</GraduationTextLength>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>Horizontal</Type>
 		<ID>Piston_ChtGauge</ID>
@@ -590,7 +600,7 @@
 			<End>250</End>
 		</ColorZone>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>Horizontal</Type>
 		<ID>Piston_OilTempGauge</ID>
@@ -625,7 +635,7 @@
 			</Greater>
 		</RedBlink>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>Horizontal</Type>
 		<ID>Piston_OilPressGauge</ID>
@@ -671,7 +681,7 @@
 			</Or>
 		</RedBlink>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>DoubleHorizontal</Type>
 		<ID>Piston_AltLoad</ID>
@@ -700,7 +710,7 @@
 		<BeginText></BeginText>
 		<EndText></EndText>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>DoubleHorizontal</Type>
 		<ID>Piston_VoltsGauge</ID>
@@ -734,7 +744,7 @@
 		<BeginText></BeginText>
 		<EndText></EndText>
 	  </Gauge>
-	  
+
 	  <Gauge>
 		<Type>DoubleHorizontal</Type>
 		<ID>Piston_FuelGauge</ID>
@@ -768,7 +778,7 @@
 		<GraduationLength text="True">10</GraduationLength>
 		<EndText>F</EndText>
 	  </Gauge>
-	 
+
   </EngineDisplay>
 
 </PlaneHTMLConfig>


### PR DESCRIPTION
Have added the STARTER ENGD annunciator to the warnings.

The POH mentions the following:
_After engine start, if the starter relay remains engaged, the
starter will remain energized and the [STARTER ENGD] will be
displayed in the Annunciation Window. This will eventually
lead to the failure of Bus 1._

I've checked to see if the engine is running (ENG COMBUSTION:1) and then checked if the starter is on/off (GENERAL ENG STARTER:1). This is definately a work around as I don't think we can see the electrical system busses/relays etc.