### PR TITLE
Dev Version Updated for correct EGT, Fuel Flows and Power Scaling mat…

### DIFF
--- a/bonanza-g36-improvement-project/SimObjects/Airplanes/Asobo_Bonanza_G36/engines.cfg
+++ b/bonanza-g36-improvement-project/SimObjects/Airplanes/Asobo_Bonanza_G36/engines.cfg
@@ -1,10 +1,10 @@
 [VERSION]
 major = 1
-minor = 0
+minor = 0.5
 
 [GENERALENGINEDATA]
 engine_type = 0 ; 0=Piston, 1=Jet, 2=None, 3=Helo-Turbine, 4=Rocket, 5=Turboprop
-fuel_flow_scalar = 1 ; Fuel flow scalar
+fuel_flow_scalar = 1.05 ; Fuel flow scalar ; ** Adjusted from default of 1.0 to match fuel flows at LoP @ Altitude on ISA
 min_throttle_limit = 0 ; Minimum percent throttle.  Generally negative for turbine reverser
 master_ignition_switch = 0
 starter_type = 0 ; 0=Electric, 1=Manual, 2=Bleed Air
@@ -13,10 +13,10 @@ Engine.0 = 4, 0, 1.2
 ThrustAnglesPitchHeading.0 = 0, 0
 
 [PISTON_ENGINE]
-power_scalar = 1.16 ; Piston power scalar
-cylinder_displacement = 92 ; Cubic inches per cylinder
+power_scalar = 1 ; Piston power scalar
+cylinder_displacement = 137.5 ; Cubic inches per cylinder; ** Changed back to Default
 compression_ratio = 8.5 ; Compression ratio
-number_of_cylinders = 6 ; Number of cylinders
+number_of_cylinders = 4 ; Number of cylinders; ** Changed back to Default
 max_rated_rpm = 2700 ; Max rated RPM
 max_rated_hp = 300 ; Max rated HP
 min_cruise_rpm = 1800
@@ -37,11 +37,11 @@ fuel_air_auto_mixture = 0 ; Automixture available? 0=FALSE, 1=TRUE
 auto_ignition = 0 ; Auto-Ignition available? 0=FALSE, 1=TRUE
 max_rpm_mechanical_efficiency_scalar = 1 ; Scalar on maximum RPM mechanical efficiency
 idle_rpm_mechanical_efficiency_scalar = 1
-max_rpm_friction_scalar = 1.0 ; Scalar on maximum RPM friction
-idle_rpm_friction_scalar = 0.78 ; Scalar on idle RPM friction
+max_rpm_friction_scalar = 1 ; Scalar on maximum RPM friction
+idle_rpm_friction_scalar = 0.78 ; Scalar on idle RPM friction ** Adjusted to improve idle rpm to ~680
 BestPowerSpecificFuelConsumption = 0.41 ; SFC at Best Power mixture ratio
 egt_tuning_constant = 1
-egt_peak_temperature = 1660 ; typical peak EGT: 1200 degF + 460
+egt_peak_temperature = 2100 ; ** adjusted from 1600 to fix EGT offsets.
 egt_tc = 2
 cht_tuning_constant = 1
 cht_cooling_constant = 0.65
@@ -69,7 +69,7 @@ radiator_heating_constant = 670
 radiator_tc = 0.02
 radiator_tuning_constant = 1
 magneto_order_left_right_both = 0
-engine_mechanical_efficiency_table = 0:0.77, 1200:0.5, 2000:0.51, 2300:0.52, 2500:0.554, 2700:0.552
+engine_mechanical_efficiency_table = 0:0.77, 1200:0.5, 2000:0.52, 2200:0.54, 2700:0.54 ; ** remove odd efficiency gain @ 2000 RPM. 2000:0.67 default value
 engine_friction_table = -300:-25, 300:25, 500:25, 2700:31
 manifold_efficiency_table = 0:0.2, 1:0.97
 rpm_to_oil_pressure_table = 0:0, 0.1:0.3, 0.2:0.9, 0.519:1, 0.74:1
@@ -90,9 +90,9 @@ egt_factor_from_pct_power = 0:0.5, 0.5:0.894, 0.64:0.956, 0.75:0.98, 1:1 ; Gives
 egt_delta_from_mixture_ratio = 0.043:-100, 0.05:-89.7, 0.067:-50, 0.07:0, 0.075:-4.9, 0.083:-80, 0.108:-120.5 ; Gives the EGT temperature delta (to current egt value after factor is applied) from the mixture ratio
 
 [PROPELLER]
-thrust_scalar = 1.14 ; Propeller thrust scalar
+thrust_scalar = 1.2 ; Propeller thrust scalar ;** Change back to Default
 propeller_type = 0 ; 0=Constant Speed, 1=Fixed Pitch
-propeller_diameter = 6.6 ; Propeller Diameter, (feet)
+propeller_diameter = 6.667 ; Propeller Diameter, (feet) ;** Adjusted to actual diamiater.
 propeller_blades = 3 ; Number of propeller blades
 propeller_moi = 5 ; Propeller moment of inertia
 beta_max = 29.2 ; Maximum blade pitch angle for constant speed prop, (degrees)

--- a/bonanza-g36-improvement-project/SimObjects/Airplanes/Asobo_Bonanza_G36/flight_model.cfg
+++ b/bonanza-g36-improvement-project/SimObjects/Airplanes/Asobo_Bonanza_G36/flight_model.cfg
@@ -230,7 +230,7 @@ lift_coef_at_drag_zero_flaps = 0.10000
 
 [FLIGHT_TUNING]
 cruise_lift_scalar = 1.12
-parasite_drag_scalar = 0.68
+parasite_drag_scalar = 0.72; *** Reverted it back to orignal to reduce climb / cruise performance after correcting engine torque and efficiency
 induced_drag_scalar = 1.4
 flap_induced_drag_scalar = 1
 elevator_effectiveness = 1


### PR DESCRIPTION
Change Back to Default:
cylinder_displacement = 137.5; Cubic inches per cylinder
number_of_cylinders = 4 ; Number of cylinders

The combination of the above produces 550ci, which this plane is, and also produces correct trq values of ~600ft-lbs @ 2700 rpm. The previous CORRECT values of 92ci per cylinder and 6 cylinders produce up-to 45fl-lbs LESS torque, and really screws up the fuel flow and mixture settings. I tried playing with 99ci per cylinder, but the fuel flows were really wonky, and the flow scaler was HUGE at 1.25 … IN short, rabbit hole trying to balance everything out. Let’s just pretend this is right for now and move on.

fuel_flow_scalar = 1.05 ; ** Adjusted from default of 1.0 to match fuel flows at LoP @ Altitude on ISA
This pretty much makes fuel flows within one gph LoP @ 0 - 12000ft per PoH. I chose LoP because RoP is a Hot Mess due to mixture scaling.

egt_peak_temperature = 2100 ; ** adjusted from 1600 to fix EGT offsets.
This one was interesting, by default EGT values are absolute Zero (-273c or -460f) Per a suggestion from @MrTommymxr set it to 2100. This produced correct EGT Values at all ranges for this plane. REALLY close to what I’ve seen on the YouTubes. 😉 This also doesn’t tweak fuel flow at all, which is nice.

thrust_scalar = 1.2 ; THIS IS DEFAULT.

I adjusted this back to 1.2 from 1.3 as inflight speeds were to fast. @ 1.2 I am within 1 or 2 kts LoP on an ISA day 2k to 12k.
